### PR TITLE
Remove hard coded region

### DIFF
--- a/src/stepwise/iam.clj
+++ b/src/stepwise/iam.clj
@@ -14,7 +14,7 @@
 (def assume-role-policy
   {"Version"   "2012-10-17",
    "Statement" [{"Effect"    "Allow",
-                 "Principal" {"Service" "states.us-west-2.amazonaws.com"},
+                 "Principal" {"Service" "states.amazonaws.com"},
                  "Action"    "sts:AssumeRole"}]})
 
 (def execution-policy


### PR DESCRIPTION
This fixes the error

The principal states.amazonaws.com is not authorized to assume the provided role.

that shows up when using a lambda task, instead of a local function.

